### PR TITLE
ci: Add Release Please Github Action workflow

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,0 +1,24 @@
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+  pull-requests: write
+
+name: release-please
+
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: googleapis/release-please-action@v4
+        with:
+          # this assumes that you have created a personal access token
+          # (PAT) and configured it as a GitHub action secret named
+          # `MY_RELEASE_PLEASE_TOKEN` (this secret name is not important).
+          token: ${{ secrets.MY_RELEASE_PLEASE_TOKEN }}
+          # this is a built-in strategy in release-please, see "Action Inputs"
+          # for more options
+          release-type: simple


### PR DESCRIPTION
Ref: https://github.com/marketplace/actions/release-please-action

Created a corresponding Personal Access Token (PAT), MY_RELEASE_PLEASE_TOKEN, with the following fine-grained permissions permissions scoped to the `penguinspiral/mayflies` repository:

* `Metadata`      : Read (mandatory)
* `Content`       : It needs read/write (Create releases is write permissions)
* `Actions`       : It needs read/write (POST dispatch jobs is write permissions)
* `Pull requests` : It needs read/write (Create PR is write permission level)

Ref: https://github.com/googleapis/release-please-action/issues/818#issuecomment-2809716722

This PAT token is in turn consumed as a Github secret in the `penguinspiral/mayflies` repository as MY_RELEASE_PLEASE_TOKEN.